### PR TITLE
Use safe_write_file, backup damaged network files

### DIFF
--- a/locale/de.txt
+++ b/locale/de.txt
@@ -9,6 +9,7 @@ allows to dig travelnet boxes which belog to nets of other players = erlaubt es,
 
 [Mod travelnet] Error: Savefile '%s' could not be written. = [Mod travelnet] Fehler: Sicherungsdatei '%s' konnte nicht geschrieben werden.
 [Mod travelnet] Error: Savefile '%s' not found. = [Mod travelnet] Fehler: Sicherungsdatei '%s' nicht gefunden.
+[Mod travelnet] Error: Savefile '%s' is damaged. Saved the backup as '%s'. = [Mod travelnet] Fehler: Sicherungsdatei '%s' ist beschädigt. Backup wurde unter '%s' gespeichert.
 
 Back = Zurück
 Exit = Ende

--- a/locale/template.txt
+++ b/locale/template.txt
@@ -9,6 +9,7 @@ allows to dig travelnet boxes which belog to nets of other players =
 
 [Mod travelnet] Error: Savefile '%s' could not be written. =
 [Mod travelnet] Error: Savefile '%s' not found. =
+[Mod travelnet] Error: Savefile '%s' is damaged. Saved the backup as '%s'. =
 
 Back =
 Exit =


### PR DESCRIPTION
I tried to adapt your code style, please tell me when there's something to change.
A user reported the following error:
```
2018-10-28 01:12:52: ERROR[Main]: ServerError: AsyncErr: ServerThread::run Lua: Runtime error from mod 'travelnet' in callback node_on_receive_fields(): .../survivalneu/minetest/bin/../mods/travelnet/init.lua:529: attempt to index field 'targets' (a nil value)                                                                                                                                                            
2018-10-28 01:12:52: ERROR[Main]: stack traceback:                                                                                                                                                              
2018-10-28 01:12:52: ERROR[Main]:       .../survivalneu/minetest/bin/../mods/travelnet/init.lua:529: in function 'add_target'                                                                                   
2018-10-28 01:12:52: ERROR[Main]:       .../survivalneu/minetest/bin/../mods/travelnet/init.lua:661: in function <.../survivalneu/minetest/bin/../mods/travelnet/init.lua:633> 
```
Most likely it's the file which was damaged (de-serialization returned nil).