### PR TITLE
allow elevator to build into any buildable node

### DIFF
--- a/elevator.lua
+++ b/elevator.lua
@@ -106,11 +106,11 @@ minetest.register_node("travelnet:elevator", {
 		fixed = {
 
 			{ 0.48, -0.5,-0.5,  0.5,  0.5, 0.5},
-			{-0.5 , -0.5, 0.48, 0.48, 0.5, 0.5}, 
+			{-0.5 , -0.5, 0.48, 0.48, 0.5, 0.5},
 			{-0.5,  -0.5,-0.5 ,-0.48, 0.5, 0.5},
 
 			--groundplate to stand on
-			{ -0.5,-0.5,-0.5,0.5,-0.48, 0.5}, 
+			{ -0.5,-0.5,-0.5,0.5,-0.48, 0.5},
 		},
 	},
 
@@ -128,7 +128,7 @@ minetest.register_node("travelnet:elevator", {
         meta:set_string("station_network","");
         meta:set_string("owner",          placer:get_player_name() );
         -- request initial data
-        meta:set_string("formspec", 
+        meta:set_string("formspec",
                             "size[12,10]"..
                             "field[0.3,5.6;6,0.7;station_name;"..S("Name of this station:")..";]"..
 --                            "field[0.3,6.6;6,0.7;station_network;Assign to Network:;]"..
@@ -140,7 +140,7 @@ minetest.register_node("travelnet:elevator", {
        minetest.add_node(p, {name="travelnet:elevator_top", paramtype2="facedir", param2=p2})
        travelnet.show_nearest_elevator( pos, placer:get_player_name(), p2 );
     end,
-    
+
     on_receive_fields = travelnet.on_receive_fields,
     on_punch          = function(pos, node, puncher)
                              travelnet.update_formspec(pos, puncher:get_player_name())
@@ -162,8 +162,9 @@ minetest.register_node("travelnet:elevator", {
     on_place = function(itemstack, placer, pointed_thing)
        local pos  = pointed_thing.above;
        local node = minetest.get_node({x=pos.x, y=pos.y+1, z=pos.z});
+	   local def = minetest.registered_nodes[node.name]
        -- leftover elevator_top nodes can be removed by placing a new elevator underneath
-       if( node ~= nil and node.name ~= "air" and node.name ~= 'travelnet:elevator_top') then
+       if not def or not def.buildable_to then
           minetest.chat_send_player( placer:get_player_name(), S('Not enough vertical space to place the travelnet box!'))
           return;
        end

--- a/travelnet.lua
+++ b/travelnet.lua
@@ -25,13 +25,13 @@ minetest.register_node("travelnet:travelnet", {
 		fixed = {
 
 			{ 0.45, -0.5,-0.5,  0.5,  1.45, 0.5},
-			{-0.5 , -0.5, 0.45, 0.45, 1.45, 0.5}, 
+			{-0.5 , -0.5, 0.45, 0.45, 1.45, 0.5},
 			{-0.5,  -0.5,-0.5 ,-0.45, 1.45, 0.5},
 
 			--groundplate to stand on
-			{ -0.5,-0.5,-0.5,0.5,-0.45, 0.5}, 
+			{ -0.5,-0.5,-0.5,0.5,-0.45, 0.5},
 			--roof
-			{ -0.5, 1.45,-0.5,0.5, 1.5, 0.5}, 
+			{ -0.5, 1.45,-0.5,0.5, 1.5, 0.5},
 
 			-- control panel
 			--                { -0.2, 0.6,  0.3, 0.2, 1.1,  0.5},
@@ -52,7 +52,7 @@ minetest.register_node("travelnet:travelnet", {
 	travelnet.reset_formspec( meta );
         meta:set_string("owner",          placer:get_player_name() );
     end,
-    
+
     on_receive_fields = travelnet.on_receive_fields,
     on_punch          = function(pos, node, puncher)
                              travelnet.update_formspec(pos, puncher:get_player_name(), nil)
@@ -74,8 +74,8 @@ minetest.register_node("travelnet:travelnet", {
     on_place = function(itemstack, placer, pointed_thing)
 
        local pos = pointed_thing.above;
-       local def = minetest.registered_nodes[
-             minetest.get_node({x=pos.x, y=pos.y+1, z=pos.z}).name]
+       local node = minetest.get_node({x=pos.x, y=pos.y+1, z=pos.z})
+       local def = minetest.registered_nodes[node.name]
        if not def or not def.buildable_to then
 
           minetest.chat_send_player( placer:get_player_name(), S('Not enough vertical space to place the travelnet box!'))


### PR DESCRIPTION
Allow the elevator to extend into any space that contains a node which is buildable_to (i.e. not just air), like the travelnet.

Sorry, but my IDE also cleaned up some trailing whitespace, so a lot more lines look modified than actually are.