### PR TITLE
extend travelnet.allow_dig with a pos param

### DIFF
--- a/config.lua
+++ b/config.lua
@@ -100,7 +100,7 @@ end
 -- if this returns true, a player named player_name can remove a travelnet station
 -- from network_name (owned by owner_name) even though he is neither the owner nor
 -- has the travelnet_remove priv
-travelnet.allow_dig    = function( player_name, owner_name, network_name )
+travelnet.allow_dig    = function( player_name, owner_name, network_name, pos )
    return false;
 end
 

--- a/init.lua
+++ b/init.lua
@@ -706,7 +706,7 @@ travelnet.on_receive_fields = function(pos, formname, fields, player)
       -- players with travelnet_remove priv can dig the station
       if( not(minetest.check_player_privs(name, {travelnet_remove=true}))
        -- the function travelnet.allow_dig(..) may allow additional digging
-       and not(travelnet.allow_dig( name, owner, network_name ))
+       and not(travelnet.allow_dig( name, owner, network_name, pos ))
        -- the owner can remove the station
        and owner ~= name
        -- stations without owner can be removed by anybody
@@ -974,7 +974,7 @@ travelnet.can_dig_old = function( pos, player, description )
 
    -- players with that priv can dig regardless of owner
    if( minetest.check_player_privs(name, {travelnet_remove=true})
-       or travelnet.allow_dig( name, owner, network_name )) then
+       or travelnet.allow_dig( name, owner, network_name, pos )) then
       return true;
    end
 


### PR DESCRIPTION
## Overview

Extends the `allow_dig` call with a *pos* parameter:

```lua
travelnet.allow_dig( name, owner, network_name, pos )
```

## Use-case

Allows for fine-grained remove decisions, for example depending on the travelnets protection