### PR TITLE
Corrects typo : belog --> belong

### DIFF
--- a/init.lua
+++ b/init.lua
@@ -101,7 +101,7 @@ travelnet.S = S
 
 
 minetest.register_privilege("travelnet_attach", { description = S("allows to attach travelnet boxes to travelnets of other players"), give_to_singleplayer = false});
-minetest.register_privilege("travelnet_remove", { description = S("allows to dig travelnet boxes which belog to nets of other players"), give_to_singleplayer = false});
+minetest.register_privilege("travelnet_remove", { description = S("allows to dig travelnet boxes which belong to nets of other players"), give_to_singleplayer = false});
 
 -- read the configuration
 dofile(travelnet.path.."/config.lua"); -- the normal, default travelnet

--- a/locale/de.po
+++ b/locale/de.po
@@ -23,7 +23,7 @@ msgid "allows to attach travelnet boxes to travelnets of other players"
 msgstr "erlaubt es, Stationen zu den Reisenetzwerken anderer Spieler hinzuzufügen"
 
 #: init.lua
-msgid "allows to dig travelnet boxes which belog to nets of other players"
+msgid "allows to dig travelnet boxes which belong to nets of other players"
 msgstr "erlaubt es, die Reisenetz-Stationen anderer Spieler zu entfernen"
 
 #: init.lua

--- a/locale/es.po
+++ b/locale/es.po
@@ -114,7 +114,7 @@ msgid "allows to attach travelnet boxes to travelnets of other players"
 msgstr "permite adjuntar cajas de viaje a redes de otros jugadores"
 
 #: init.lua
-msgid "allows to dig travelnet boxes which belog to nets of other players"
+msgid "allows to dig travelnet boxes which belong to nets of other players"
 msgstr ""
 "permite cavar cabinas de viaje pertenecientes a redes de otros jugadores"
 

--- a/locale/ru.po
+++ b/locale/ru.po
@@ -114,7 +114,7 @@ msgid "allows to attach travelnet boxes to travelnets of other players"
 msgstr "позволяет присоеденять телепорты к сетям других игроков"
 
 #: init.lua
-msgid "allows to dig travelnet boxes which belog to nets of other players"
+msgid "allows to dig travelnet boxes which belong to nets of other players"
 msgstr "позволяет убирать телепорты других игроков"
 
 #: init.lua

--- a/locale/template.pot
+++ b/locale/template.pot
@@ -104,7 +104,7 @@ msgid "allows to attach travelnet boxes to travelnets of other players"
 msgstr ""
 
 #: init.lua
-msgid "allows to dig travelnet boxes which belog to nets of other players"
+msgid "allows to dig travelnet boxes which belong to nets of other players"
 msgstr ""
 
 #: init.lua


### PR DESCRIPTION
Corrects typo : belog --> belong