### PR TITLE
Use hidden node to stop placement of blocks in top half of travelnet

### DIFF
--- a/depends.txt
+++ b/depends.txt
@@ -1,2 +1,3 @@
 mesecons?
+mesecons_mvps?
 intllib?

--- a/elevator.lua
+++ b/elevator.lua
@@ -106,11 +106,11 @@ minetest.register_node("travelnet:elevator", {
 		fixed = {
 
 			{ 0.48, -0.5,-0.5,  0.5,  0.5, 0.5},
-			{-0.5 , -0.5, 0.48, 0.48, 0.5, 0.5}, 
+			{-0.5 , -0.5, 0.48, 0.48, 0.5, 0.5},
 			{-0.5,  -0.5,-0.5 ,-0.48, 0.5, 0.5},
 
 			--groundplate to stand on
-			{ -0.5,-0.5,-0.5,0.5,-0.48, 0.5}, 
+			{ -0.5,-0.5,-0.5,0.5,-0.48, 0.5},
 		},
 	},
 
@@ -128,7 +128,7 @@ minetest.register_node("travelnet:elevator", {
         meta:set_string("station_network","");
         meta:set_string("owner",          placer:get_player_name() );
         -- request initial data
-        meta:set_string("formspec", 
+        meta:set_string("formspec",
                             "size[12,10]"..
                             "field[0.3,5.6;6,0.7;station_name;"..S("Name of this station:")..";]"..
 --                            "field[0.3,6.6;6,0.7;station_network;Assign to Network:;]"..
@@ -140,7 +140,7 @@ minetest.register_node("travelnet:elevator", {
        minetest.add_node(p, {name="travelnet:elevator_top", paramtype2="facedir", param2=p2})
        travelnet.show_nearest_elevator( pos, placer:get_player_name(), p2 );
     end,
-    
+
     on_receive_fields = travelnet.on_receive_fields,
     on_punch          = function(pos, node, puncher)
                              travelnet.update_formspec(pos, puncher:get_player_name())
@@ -162,8 +162,9 @@ minetest.register_node("travelnet:elevator", {
     on_place = function(itemstack, placer, pointed_thing)
        local pos  = pointed_thing.above;
        local node = minetest.get_node({x=pos.x, y=pos.y+1, z=pos.z});
+	   local def = minetest.registered_nodes[node.name]
        -- leftover elevator_top nodes can be removed by placing a new elevator underneath
-       if( node ~= nil and node.name ~= "air" and node.name ~= 'travelnet:elevator_top') then
+       if not def or not def.buildable_to then
           minetest.chat_send_player( placer:get_player_name(), S('Not enough vertical space to place the travelnet box!'))
           return;
        end

--- a/init.lua
+++ b/init.lua
@@ -716,6 +716,13 @@ travelnet.on_receive_fields = function(pos, formname, fields, player)
          return
       end
 
+      if minetest.get_modpath("areas") and areas.canInteract then
+         if owner ~= name and not areas:canInteract(pos, name) then
+            minetest.chat_send_player(name, S("You cannot remove this travelnet from an area you don't control"))
+            return
+         end
+      end
+
       local pinv = player:get_inventory()
       if(not(pinv:room_for_item("main", node.name))) then
          minetest.chat_send_player(name, S("You do not have enough room in your inventory."));

--- a/init.lua
+++ b/init.lua
@@ -910,6 +910,8 @@ end
 
 travelnet.remove_box = function( pos, oldnode, oldmetadata, digger )
 
+   minetest.remove_node(vector.add({x=0,y=1,z=0}, pos))
+
    if( not( oldmetadata ) or oldmetadata=="nil" or not(oldmetadata.fields)) then
       minetest.chat_send_player( digger:get_player_name(), S("Error")..": "..
 		S("Could not find information about the station that is to be removed."));
@@ -988,9 +990,30 @@ travelnet.can_dig_old = function( pos, player, description )
    end
    return true;
 end
+local hidden_def = {
+  drawtype = "airlike",
+  paramtype = "light",
+  sunlight_propagates = true,
+  walkable = true,
+  pointable = false,
+  diggable = false,
+  builbable_to = false,
+  floodable = false,
+  drop="",
+  groups = {not_in_creative_inventory = 1},
+  on_blast = function () end,
+  collision_box = {
+    type = "fixed",
+    fixed = { 0,0,0,0,0,0 },
+  },
+}
 
+-- Make hidden node visible for debugging
+-- hidden_def.selection_box = {type="fixed",fixed={-0.3,-0.3,-0.3,0.3,0.3,0.3}}
+-- hidden_def.pointable = true
+-- hidden_def.drawtype = "glasslike"
 
-
+minetest.register_node("travelnet:hidden_top", hidden_def)
 
 
 if( travelnet.travelnet_effect_enabled ) then

--- a/init.lua
+++ b/init.lua
@@ -282,6 +282,13 @@ travelnet.update_formspec = function( pos, puncher_name, fields )
 
 
       if( is_elevator == true ) then
+         if minetest.get_modpath("areas") and areas.canInteract then
+            if owner_name ~= puncher_name and not areas:canInteract(pos, puncher_name) then
+               minetest.chat_send_player(puncher_name, S("You cannot configure an elevator in an area you don't control"))
+               return
+            end
+         end
+
          travelnet.add_target( nil, nil, pos, puncher_name, meta, owner_name );
          return;
       end
@@ -738,12 +745,14 @@ travelnet.on_receive_fields = function(pos, formname, fields, player)
       return;
    end
 
-
-
-
    -- if the box has not been configured yet
    if( meta:get_string("station_network")=="" ) then
-
+      if minetest.get_modpath("areas") and areas.canInteract then
+         if fields.owner ~= name and not areas:canInteract(pos, name) then
+            minetest.chat_send_player(name, S("You cannot configure in an area you don't control"))
+            return
+         end
+      end
       travelnet.add_target( fields.station_name, fields.station_network, pos, name, meta, fields.owner );
       return;
    end

--- a/init.lua
+++ b/init.lua
@@ -123,7 +123,7 @@ end
 
 
 travelnet.restore_data = function()
-   
+
    local file = io.open( travelnet.mod_data_path, "r" );
    if( not file ) then
       print(S("[Mod travelnet] Error: Savefile '%s' not found.")
@@ -204,7 +204,8 @@ end
 -- (back from help page, moved travelnet up or down etc.)
 travelnet.form_input_handler = function( player, formname, fields)
         if(formname == "travelnet:show" and fields and fields.pos2str) then
-		local pos = minetest.string_to_pos( fields.pos2str );
+		local pos = minetest.string_to_pos( fields.pos2str )
+		if not pos then return end
 		if( locks and (fields.locks_config or fields.locks_authorize)) then
 			return locks:lock_handle_input( pos, formname, fields, player )
 		end
@@ -843,7 +844,7 @@ travelnet.on_receive_fields = function(pos, formname, fields, player)
    local target_pos = travelnet.targets[ owner_name ][ station_network ][ fields.target ].pos;
    player:move_to( target_pos, false);
 
-   if( travelnet.travelnet_effect_enabled ) then 
+   if( travelnet.travelnet_effect_enabled ) then
       minetest.add_entity( {x=target_pos.x,y=target_pos.y+0.5,z=target_pos.z}, "travelnet:effect"); -- it self-destructs after 20 turns
    end
 

--- a/init.lua
+++ b/init.lua
@@ -1007,13 +1007,17 @@ local hidden_def = {
     fixed = { 0,0,0,0,0,0 },
   },
 }
-
 -- Make hidden node visible for debugging
 -- hidden_def.selection_box = {type="fixed",fixed={-0.3,-0.3,-0.3,0.3,0.3,0.3}}
 -- hidden_def.pointable = true
 -- hidden_def.drawtype = "glasslike"
 
 minetest.register_node("travelnet:hidden_top", hidden_def)
+
+if minetest.global_exists("mesecon") and mesecon.register_mvps_stopper then
+  mesecon.register_mvps_stopper("travelnet:hidden_top")
+end
+
 
 
 if( travelnet.travelnet_effect_enabled ) then

--- a/mod.conf
+++ b/mod.conf
@@ -1,1 +1,3 @@
 name = travelnet
+description = Network of teleporter-boxes that allow easy travelling to other boxes on the same network.
+optional_depends = areas, intllib, mesecons

--- a/travelnet.lua
+++ b/travelnet.lua
@@ -25,13 +25,13 @@ minetest.register_node("travelnet:travelnet", {
 		fixed = {
 
 			{ 0.45, -0.5,-0.5,  0.5,  1.45, 0.5},
-			{-0.5 , -0.5, 0.45, 0.45, 1.45, 0.5}, 
+			{-0.5 , -0.5, 0.45, 0.45, 1.45, 0.5},
 			{-0.5,  -0.5,-0.5 ,-0.45, 1.45, 0.5},
 
 			--groundplate to stand on
-			{ -0.5,-0.5,-0.5,0.5,-0.45, 0.5}, 
+			{ -0.5,-0.5,-0.5,0.5,-0.45, 0.5},
 			--roof
-			{ -0.5, 1.45,-0.5,0.5, 1.5, 0.5}, 
+			{ -0.5, 1.45,-0.5,0.5, 1.5, 0.5},
 
 			-- control panel
 			--                { -0.2, 0.6,  0.3, 0.2, 1.1,  0.5},
@@ -52,7 +52,7 @@ minetest.register_node("travelnet:travelnet", {
 	travelnet.reset_formspec( meta );
         meta:set_string("owner",          placer:get_player_name() );
     end,
-    
+
     on_receive_fields = travelnet.on_receive_fields,
     on_punch          = function(pos, node, puncher)
                              travelnet.update_formspec(pos, puncher:get_player_name(), nil)
@@ -74,8 +74,8 @@ minetest.register_node("travelnet:travelnet", {
     on_place = function(itemstack, placer, pointed_thing)
 
        local pos = pointed_thing.above;
-       local def = minetest.registered_nodes[
-             minetest.get_node({x=pos.x, y=pos.y+1, z=pos.z}).name]
+       local node = minetest.get_node({x=pos.x, y=pos.y+1, z=pos.z})
+       local def = minetest.registered_nodes[node.name]
        if not def or not def.buildable_to then
 
           minetest.chat_send_player( placer:get_player_name(), S('Not enough vertical space to place the travelnet box!'))

--- a/travelnet.lua
+++ b/travelnet.lua
@@ -92,3 +92,7 @@ minetest.register_craft({
         output = "travelnet:travelnet",
         recipe = travelnet.travelnet_recipe,
 })
+
+if minetest.global_exists("mesecon") and mesecon.register_mvps_stopper then
+    mesecon.register_mvps_stopper("travelnet:travelnet")
+end

--- a/travelnet.lua
+++ b/travelnet.lua
@@ -48,9 +48,11 @@ minetest.register_node("travelnet:travelnet", {
     light_source = 10,
 
     after_place_node  = function(pos, placer, itemstack)
-	local meta = minetest.get_meta(pos);
-	travelnet.reset_formspec( meta );
-        meta:set_string("owner",          placer:get_player_name() );
+		local meta = minetest.get_meta(pos);
+		travelnet.reset_formspec( meta );
+		meta:set_string("owner", placer:get_player_name() );
+		local top_pos = vector.add({x=0,y=1,z=0}, pos)
+		minetest.set_node(top_pos, {name="travelnet:hidden_top"})
     end,
     
     on_receive_fields = travelnet.on_receive_fields,
@@ -74,10 +76,9 @@ minetest.register_node("travelnet:travelnet", {
     on_place = function(itemstack, placer, pointed_thing)
 
        local pos = pointed_thing.above;
-       local def = minetest.registered_nodes[
-             minetest.get_node({x=pos.x, y=pos.y+1, z=pos.z}).name]
-       if not def or not def.buildable_to then
-
+       local node = minetest.get_node({x=pos.x, y=pos.y+1, z=pos.z})
+       local def = minetest.registered_nodes[node.name]
+       if (not def or not def.buildable_to) and node.name ~= "travelnet:hidden_top" then
           minetest.chat_send_player( placer:get_player_name(), S('Not enough vertical space to place the travelnet box!'))
           return;
        end


### PR DESCRIPTION
Fixes #55 

Create a new hidden node, place it in the top half of the travelnet on creation, and remove it on deletion